### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
     name: Deploy to preview environment
     runs-on: ubuntu-latest
     needs: [inject-html]
+    permissions:
+      contents: read
     steps:
       - name: Compile the source
         run: echo compile placeholder


### PR DESCRIPTION
Potential fix for [https://github.com/trymnilsen/kingdomarchitect/security/code-scanning/7](https://github.com/trymnilsen/kingdomarchitect/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the `deploy-preview` job to explicitly define the least privileges required for the task. Since the job does not appear to interact with the repository contents or require write access, we can set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unintended modifications.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
